### PR TITLE
Ux/update handling

### DIFF
--- a/src/unwetter/dwd.py
+++ b/src/unwetter/dwd.py
@@ -215,6 +215,21 @@ def parse_xml(xml):
 
         event['special_type'] = special_type(event, old_events)
 
+        if not event['has_changes']:
+            list_all_refs = [old_event['references'] for old_event in old_events if old_event['published']]
+            published_refs = []
+            for refs in list_all_refs:
+                published_refs.extend(refs)
+            event['references'] = published_refs
+
+            event['has_changes'] = [
+                {
+                    'id': old_event['id'],
+                    'changed': bool(changes(event, old_event)),
+                }
+                for old_event in old_events
+            ]
+
     event['published'] = False
 
     return event

--- a/src/unwetter/dwd.py
+++ b/src/unwetter/dwd.py
@@ -209,26 +209,17 @@ def parse_xml(xml):
             {
                 'id': old_event['id'],
                 'changed': bool(changes(event, old_event)),
+                'published': old_event['published'],
             }
             for old_event in old_events
         ]
 
         event['special_type'] = special_type(event, old_events)
 
-        if not event['has_changes']:
+        if not any(t['published'] for t in event['has_changes']):
             list_all_refs = [old_event['references'] for old_event in old_events if old_event['published']]
-            published_refs = []
             for refs in list_all_refs:
-                published_refs.extend(refs)
-            event['references'] = published_refs
-
-            event['has_changes'] = [
-                {
-                    'id': old_event['id'],
-                    'changed': bool(changes(event, old_event)),
-                }
-                for old_event in old_events
-            ]
+                event['references'].extend(refs)
 
     event['published'] = False
 

--- a/src/unwetter/dwd.py
+++ b/src/unwetter/dwd.py
@@ -217,9 +217,9 @@ def parse_xml(xml):
         event['special_type'] = special_type(event, old_events)
 
         if not any(t['published'] for t in event['has_changes']):
-            list_all_refs = [old_event['references'] for old_event in old_events if old_event['published']]
-            for refs in list_all_refs:
-                event['references'].extend(refs)
+            for old_event in old_events:
+                if 'references' in old_event:
+                    event['references'].extend(old_event['references'])
 
     event['published'] = False
 

--- a/src/unwetter/generate/blocks.py
+++ b/src/unwetter/generate/blocks.py
@@ -187,7 +187,9 @@ def changes(event, old_event):
                 text += f'{simple_fields[field]}: {event[field]} ' \
                         f'(zuvor "{old_event.get(field, "Nicht angegeben")}")\n'
 
-    if dates(old_event) != dates(event):
+    if dates(old_event)[-9:] != dates(event)[-9:]:
+        # Editorial request to check only, if expires time changed, since every update has new onset-time
+        # Format of dates : 'HH:MM Uhr'
         text += f'Gültigkeit: {dates(event)} (zuvor "{dates(old_event)}")\n\n'
 
     if district_list(old_event) != district_list(event):
@@ -215,8 +217,11 @@ def changes(event, old_event):
         else:
             text += f'Regionale Zuordnung unverändert: {upper_first(region_list(event))}\n\n'
 
+    '''
+    # Editorial choice --> No relevant information due to relatively small area --> Thus, no update
+
     elif commune_list(old_event) != commune_list(event):
         text += 'Regionale Zuordnung: Änderung der betroffenen Gemeinden\n\n'
-
+    '''
 
     return text


### PR DESCRIPTION
We only publish updates to published references. Otherwise, it will be handled as an Alert.

Starting with a published_event, we compare the update_n with this alert. If this is not published, it's because it doesn't have relevant changes.
If then update_n+1 has relevant changes to update_n,
it implicitly has changes to the last published_event. To be able to compare these, it is necessary, to have the published_event in the list of references of update_n+1.
Else if update_n+1 does not have relevant changes to update_n, it implicitly won't have relevant changes to the last published_event. Thus, we append our list of references of update_n+1 with the published references of update_n , which will due to recursion contain the last published event.